### PR TITLE
Move to restify way of recording endpoint timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
+<a name="1.1.1"></a>
+## 1.1.1 (2016-07-21)
+
+* Move to restify way of recording endpoint timing ([d60f382](https://github.com/daptiv/api-metrics-client/commit/d60f382))
+* var => let ([f75f183](https://github.com/daptiv/api-metrics-client/commit/f75f183))
+
+
+
 <a name="1.1.0"></a>
 # 1.1.0 (2016-05-31)
 
+* 1.1.0 ([b50d0a6](https://github.com/daptiv/api-metrics-client/commit/b50d0a6))
+* docs(changelog): update changelog ([a1bd655](https://github.com/daptiv/api-metrics-client/commit/a1bd655))
 * refactor(metrics): add statusCode to metrics key ([77bb71a](https://github.com/daptiv/api-metrics-client/commit/77bb71a))
 * refactor(metrics): allow custom typings to be installed and expose metrics ([1815cc0](https://github.com/daptiv/api-metrics-client/commit/1815cc0))
 * refactor(metrics): refine determination of metrics key ([330d8c7](https://github.com/daptiv/api-metrics-client/commit/330d8c7))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-metrics-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/metrics-logger.ts
+++ b/src/metrics-logger.ts
@@ -27,7 +27,7 @@ export class MetricsLogFactory {
 
     createLogger() {
         return (request: Request, response: Response, route: Route) => {
-            var latency = response.header('Response-Time');
+            let latency = response.header('Response-Time');
 
             if (typeof (latency) !== 'number') {
                 latency = Date.now() - request.time();

--- a/src/metrics-logger.ts
+++ b/src/metrics-logger.ts
@@ -27,30 +27,20 @@ export class MetricsLogFactory {
 
     createLogger() {
         return (request: Request, response: Response, route: Route) => {
-            // Ignore requests without timers, e.g. OPTIONS
-            if (!request.timers) {
-                return;
+            var latency = response.header('Response-Time');
+
+            if (typeof (latency) !== 'number') {
+                latency = Date.now() - request.time();
             }
 
-            let timer = request.timers.find((item) => {
-                return item.name === route.name || item.name === DEFAULT_KEY_NAME;
-            });
-            if (!timer) {
+            if (!latency) {
                 return;
             }
 
             let routeSpec: RouteSpec = route && route.spec;
-            let key: string = this.metricsKeyBuilder.fromRouteSpecAndStatus(routeSpec, response.statusCode);
-            let time = this.toMilliseconds(timer.time);
-            if (time) {
-                this.statsD.timing(key, time);
-            }
-        };
-    }
 
-    private toMilliseconds(hrTime: HighResolutionTime): number {
-        let milliSeconds = hrTime[0] * 1000;
-        milliSeconds += hrTime[1] / 1000000;
-        return milliSeconds;
+            let key: string = this.metricsKeyBuilder.fromRouteSpecAndStatus(routeSpec, response.statusCode);
+            this.statsD.timing(key, latency);
+        };
     }
 };

--- a/src/spec/metrics-logger.ts
+++ b/src/spec/metrics-logger.ts
@@ -13,13 +13,16 @@ describe('metrics-logger', () => {
     let logger;
     let statsDSpy;
     let metricsKeyBuilder = new MetricsKeyBuilder();
-    let mockRequest = jasmine.createSpyObj('mockRequest', ['']);
-    let mockResponse = jasmine.createSpyObj('mockResponse', ['']);
+    let mockRequest;
+    let mockResponse;
     let mockRoute = <Route>{};
     let routeSpec: RouteSpec;
 
     beforeEach(() => {
         statsDSpy = jasmine.createSpyObj('statsDSpy', ['timing']);
+        mockRequest = jasmine.createSpyObj('mockRequest', ['time']);
+        mockResponse = jasmine.createSpyObj('mockResponse', ['header']);
+
         metricsLogger.registerHandledRouteTimingMetrics(serverSpy, statsDOptions);
         logger = new metricsLogger.MetricsLogFactory(statsDSpy, metricsKeyBuilder).createLogger();
         mockResponse.statusCode = 200;
@@ -37,49 +40,29 @@ describe('metrics-logger', () => {
         expect(serverSpy.on).toHaveBeenCalledWith('after', jasmine.any(Function));
     });
 
-    it('when request timer not available for route should not record time', () => {
-        mockRequest.timers = [];
+    it('when response Response-Time header is available should record time for route', () => {
+        mockResponse.header.and.callFake((headerName) => { return headerName === 'Response-Time' ? 123 : null });
+
+        logger(mockRequest, mockResponse, mockRoute);
+
+        expect(statsDSpy.timing).toHaveBeenCalledWith('tasks.200', 123);
+    });
+
+    it('when response Response-Time header is unavailable should record time for route', () => {
+        spyOn(Date,'now').and.callFake(() => { return 40 });
+        mockRequest.time.and.callFake(() => { return 30 });
+        mockResponse.header.and.callFake((headerName) => { return null });
+
+        logger(mockRequest, mockResponse, mockRoute);
+
+        expect(statsDSpy.timing).toHaveBeenCalledWith('tasks.200', 10);
+    });
+
+    it('when both response Response-Time header and request time is unavailable should not record time', () => {
+        mockResponse.header.and.callFake((headerName) => { return null });
 
         logger(mockRequest, mockResponse, mockRoute);
 
         expect(statsDSpy.timing).not.toHaveBeenCalled();
-    });
-
-    it('when request timer is available for route should record time for route', () => {
-        mockRequest.timers = [{name: 'route-1', time: [0, 10]}, {name: 'route-2', time: [0, 20]}, {name: 'route-3', time: [0, 30]}];
-        mockRoute.name = 'route-2';
-
-        logger(mockRequest, mockResponse, mockRoute);
-
-        expect(statsDSpy.timing).toHaveBeenCalledWith('tasks.200', jasmine.any(Number));
-    });
-
-    describe('metrics timer\'s time', () => {
-        it('should be converted (seconds only) to ms', () => {
-            mockRequest.timers = [{name: 'route-1', time: [5, 0]}];
-            mockRoute.name = 'route-1';
-
-            logger(mockRequest, mockResponse, mockRoute);
-
-            expect(statsDSpy.timing).toHaveBeenCalledWith(jasmine.any(String), 5000);
-        });
-
-        it('should be converted (seconds & ns) to ms', () => {
-            mockRequest.timers = [{name: 'route-1', time: [5, 2000000]}];
-            mockRoute.name = 'route-1';
-
-            logger(mockRequest, mockResponse, mockRoute);
-
-            expect(statsDSpy.timing).toHaveBeenCalledWith(jasmine.any(String), 5002);
-        });
-
-        it('should be converted (ns only) to ms', () => {
-            mockRequest.timers = [{name: 'route-1', time: [0, 1000010]}];
-            mockRoute.name = 'route-1';
-
-            logger(mockRequest, mockResponse, mockRoute);
-
-            expect(statsDSpy.timing).toHaveBeenCalledWith(jasmine.any(String), 1.000010);
-        });
     });
 });


### PR DESCRIPTION
Apparently, when using **any** pre restify plugins, this code starts causing gateway timeouts because route can be null (don't know enough about restify's internals to know how):

``` js
let timer = request.timers.find((item) => {
   return item.name === route.name || item.name === DEFAULT_KEY_NAME;
});
```

I figured the safest fix is to just move to Restify's way of recording the time a request takes:
https://github.com/restify/plugins/blob/master/lib/plugins/audit.js#L111-L116
### Reviewers
- [x] @jtrinklein 
- [x] @chrisbobo 
